### PR TITLE
Add HAL GPIO abstraction and fix unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ set(CMAKE_C_STANDARD 11)
 add_executable(firmware
     src/main.c
     src/app.c
+    src/hal_gpio.c
 )
 
 target_include_directories(firmware PRIVATE include)

--- a/include/app.h
+++ b/include/app.h
@@ -2,6 +2,6 @@
 #define APP_H
 
 void app_init(void);
-int add(int a, int b);
+void led_on(void);
 
-#endif
+#endif // APP_H

--- a/include/hal_gpio.h
+++ b/include/hal_gpio.h
@@ -1,0 +1,12 @@
+#ifndef HAL_GPIO_H
+#define HAL_GPIO_H
+
+#define GPIO_PORT_LED 0
+#define GPIO_PIN_LED 13
+
+#define GPIO_PIN_RESET 0
+#define GPIO_PIN_SET 1
+
+void HAL_GPIO_WritePin(int port, int pin, int value);
+
+#endif // HAL_GPIO_H

--- a/src/app.c
+++ b/src/app.c
@@ -1,21 +1,19 @@
 #include "app.h"
+
 #include <stdio.h>
-#include "app.h"
 
 #ifdef UNIT_TEST
 #include "mock_hal_gpio.h"
 #else
-#include "hal_gpio.h"  
+#include "hal_gpio.h"
 #endif
 
-void led_on(void)
+void app_init(void)
 {
-    HAL_GPIO_WritePin(0, 13, 1);
-}
-void app_init(void) {
     printf("app_init called\n");
 }
 
-int add(int a, int b) {
-    return a + b;
+void led_on(void)
+{
+    HAL_GPIO_WritePin(GPIO_PORT_LED, GPIO_PIN_LED, GPIO_PIN_SET);
 }

--- a/src/hal_gpio.c
+++ b/src/hal_gpio.c
@@ -1,0 +1,15 @@
+#include "hal_gpio.h"
+
+#include <stdio.h>
+
+void HAL_GPIO_WritePin(int port, int pin, int value)
+{
+    (void)port;
+    (void)pin;
+    (void)value;
+
+    /* Placeholder implementation: in production this should drive hardware. */
+#ifdef DEBUG
+    printf("HAL_GPIO_WritePin(port=%d, pin=%d, value=%d)\n", port, pin, value);
+#endif
+}

--- a/tests/mocks/mock_hal_gpio.h
+++ b/tests/mocks/mock_hal_gpio.h
@@ -6,12 +6,14 @@
 #define GPIO_PORT_LED 1
 #define GPIO_PIN_LED  13
 
+#define GPIO_PIN_RESET 0
+#define GPIO_PIN_SET 1
+
 // Prototype تابع HAL اصلی
 void HAL_GPIO_WritePin(int port, int pin, int value);
 
 // متغیرهای مانیتورینگ برای تست
 extern int mock_writepin_called;
 extern int mock_last_value;
-
 
 #endif

--- a/tests/test_app.c
+++ b/tests/test_app.c
@@ -13,5 +13,12 @@ void test_led_on_should_call_HAL_GPIO_WritePin(void)
     led_on(); // از app.c فراخوانی میشه
 
     TEST_ASSERT_EQUAL_INT(1, mock_writepin_called);
-    TEST_ASSERT_EQUAL_INT(1, mock_last_value);
+    TEST_ASSERT_EQUAL_INT(GPIO_PIN_SET, mock_last_value);
+}
+
+int main(void)
+{
+    UNITY_BEGIN();
+    RUN_TEST(test_led_on_should_call_HAL_GPIO_WritePin);
+    return UNITY_END();
 }


### PR DESCRIPTION
## Summary
- add a lightweight HAL GPIO interface and stubbed implementation for the firmware target
- clean up the app module to use the new abstraction and expose LED control
- refresh the Unity test harness to use the GPIO macros and add an entry point

## Testing
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68e5fcc56b30832aa51090fca1feb593