### PR TITLE
Add CI coverage reporting with lcov and gcovr

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,15 +19,15 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt update
-          sudo apt install -y ninja-build lcov clang-format gcovr
+          sudo apt install -y ninja-build lcov clang-format gcovr gcc
 
       # 3️⃣ پیکربندی CMake با فلگ‌های پوشش تست
       - name: Configure CMake project
         run: |
           cmake -S . -B build -G "Ninja" \
             -DCMAKE_BUILD_TYPE=Debug \
-            -DCMAKE_C_FLAGS="--coverage" \
-            -DCMAKE_EXE_LINKER_FLAGS="--coverage"
+            -DCMAKE_C_COMPILER=gcc \
+            -DENABLE_CODE_COVERAGE=ON
 
       # 4️⃣ بیلد پروژه
       - name: Build all targets
@@ -40,12 +40,19 @@ jobs:
      # 6️⃣ محاسبه و خروجی پوشش تست (coverage)
       - name: Generate coverage report
         run: |
-           cd build
-           lcov --capture --directory . --output-file coverage.info
-            lcov --remove coverage.info '/usr/*' 'tests/*' 'third_party/*' \
-           --ignore-errors unused --output-file coverage.info
-            lcov --list coverage.info
-            genhtml coverage.info --output-directory coverage_html
+          cd build
+          lcov --gcov-tool gcov --capture --directory . --output-file coverage.info
+          lcov --remove coverage.info '/usr/*' 'tests/*' 'third_party/*' \
+            --ignore-errors unused --output-file coverage.info
+          lcov --list coverage.info
+          genhtml coverage.info --output-directory coverage_html
+
+      # 6.5️⃣ جمع‌بندی پوشش در قالب متن
+      - name: Summarize coverage in console
+        run: |
+          gcovr --root . --object-directory build --filter src --filter include \
+            --exclude tests --xml build/coverage.xml \
+            --html-details build/coverage_gcovr/index.html --print-summary
 
 
       # 7️⃣ ذخیره گزارش به عنوان artifact

--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
 # Embedded DevOps Starter
 
 [![Build Status](https://github.com/keiraward/embedded-devops-starter/actions/workflows/ci.yml/badge.svg)](https://github.com/keiraward/embedded-devops-starter/actions)
+
+## Code coverage
+
+The CI workflow collects coverage information using `lcov`/`gcov` and publishes
+an HTML report as an artifact. You can reproduce the same report locally with
+the following commands:
+
+```sh
+cmake -S . -B build -G "Ninja" -DCMAKE_BUILD_TYPE=Debug -DENABLE_CODE_COVERAGE=ON
+cmake --build build
+cd build && ctest --output-on-failure
+lcov --gcov-tool gcov --capture --directory . --output-file coverage.info
+genhtml coverage.info --output-directory coverage_html
+```
+
+The workflow also invokes `gcovr` to emit a textual summary in the CI logs and
+to generate XML/HTML artifacts that can be consumed by other tooling.


### PR DESCRIPTION
## Summary
- enable code coverage instrumentation in the CI workflow using GCC and the CMake coverage option
- extend the workflow to generate lcov, gcovr XML/HTML artifacts and log a console summary
- document how to reproduce the lcov report locally in the README

## Testing
- cmake -S . -B build -G "Ninja" -DCMAKE_BUILD_TYPE=Debug
- cmake --build build -j
- cd build && ctest --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e62dd1d108832a817475fcd22e1996