### PR TITLE
Fix workflow artifact paths and dependency setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: firmware
+          path: build
 
       - name: Install QEMU (ARM version)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install ARM GCC
-        run: sudo apt-get install -y gcc-arm-none-eabi binutils-arm-none-eabi qemu-system-arm
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-arm-none-eabi binutils-arm-none-eabi
 
       - name: Configure
         run: cmake -B build -DCMAKE_TOOLCHAIN_FILE=toolchain-arm-gcc.cmake
@@ -36,6 +38,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
+      - name: Install QEMU (ARM)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-arm
+
       - uses: actions/download-artifact@v4
         with:
           name: firmware


### PR DESCRIPTION
## Summary
- ensure the simulation job downloads firmware artifacts into the expected build directory
- run apt-get update before installing toolchain packages in CI
- install QEMU in the simulation job so the emulator is available when running firmware

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f5bec9dd14832aa54d64a56ad0dd74