### PR TITLE
Use a supported QEMU machine for firmware simulation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,15 +22,19 @@ jobs:
 
       - name: Build firmware
         run: |
-          cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
-          cmake --build build
+          cmake -S . -B build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/toolchain-arm-gcc.cmake
+          cmake --build build --target firmware.elf
           arm-none-eabi-objcopy -O binary build/firmware.elf build/firmware.bin
 
       - name: Upload firmware artifact
         uses: actions/upload-artifact@v4
         with:
           name: firmware
-          path: build/firmware.elf
+          path: |
+            build/firmware.elf
+            build/firmware.bin
 
   simulate:
     runs-on: ubuntu-latest
@@ -43,6 +47,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: firmware
+          path: build
 
       - name: Install QEMU (ARM version)
         run: |
@@ -54,4 +59,4 @@ jobs:
 
       - name: Run firmware in QEMU
         run: |
-          qemu-system-arm -M stm32f4 -kernel build/firmware.elf -nographic -serial stdio -semihosting
+          qemu-system-arm -machine netduinoplus2 -kernel build/firmware.elf -nographic -serial stdio -semihosting

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,11 @@ jobs:
           sudo apt-get install -y gcc-arm-none-eabi binutils-arm-none-eabi
 
       - name: Configure
-        run: cmake -B build -DCMAKE_TOOLCHAIN_FILE=toolchain-arm-gcc.cmake
+        run: cmake -S . -B build \
+          -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/toolchain-arm-gcc.cmake
 
       - name: Build firmware
-        run: cmake --build build --parallel
+        run: cmake --build build --target firmware.elf --parallel
 
       - name: Convert to .bin
         run: arm-none-eabi-objcopy -O binary build/firmware.elf build/firmware.bin
@@ -49,4 +50,4 @@ jobs:
           path: build
 
       - name: Run firmware in QEMU
-        run: qemu-system-arm -M stm32-p103 -kernel build/firmware.elf -nographic -serial stdio -semihosting
+        run: qemu-system-arm -machine netduinoplus2 -kernel build/firmware.elf -nographic -serial stdio -semihosting


### PR DESCRIPTION
## Summary
- switch both workflows to use the netduinoplus2 machine that is available in the default QEMU package so the simulation job can start

## Testing
- not run (workflow changes only)

------
https://chatgpt.com/codex/tasks/task_e_68f5dc462b98832a8a27b715cc8352f9